### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Implement the module in `nuxt.config.js`:
 ...
 modules: [
     ['nuxt-parse', {
-            appID: YOUR_APP_ID,
+            appId: YOUR_APP_ID,
             javascriptKey: YOUR_JAVASCRIPT_KEY,
             serverUrl: OPTIONAL_SERVER_URL
         }


### PR DESCRIPTION
# Pull-Request #

## Changes ##
among module options: corrected appID to appId (otherwise module doesn't initialize).
Without this, Parse will complain forever that it needs to be initialized. It was just a typo in README.md : module is looking for options.appId, not options.appID

## Expected result: ##  
Now Parse should be able to use the set APPLICATION_ID, and thus initialize properly

